### PR TITLE
Call onClipspaceEditorClosed hook before closing

### DIFF
--- a/js/openpose_editor.js
+++ b/js/openpose_editor.js
@@ -52,6 +52,7 @@ class OpenposeEditorDialog extends ComfyDialog {
                 const targetNode = ComfyApp.clipspace_return_node;
                 const textAreaElement = targetNode.widgets[0].element;
                 textAreaElement.value = JSON.stringify(event.data.poses);
+                ComfyApp.onClipspaceEditorClosed();
                 this.close();
             }
         });


### PR DESCRIPTION
Fixes #9.

The "Open in MaskEditor" menu option only appears when `ComfyApp.clipspace_return_node` is null. 

This function call is used in MaskEditor of Comfy-Org/ComfyUI_frontend. It is reasonable to assume this is the proper way to set that attribute to null.